### PR TITLE
✨ [#26] 상품 이미지 최대 첨부 개수 설정

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -1,5 +1,6 @@
 package com.goodsending.global.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
 
   // BAD_REQUEST:400:잘못된요청
+  FILE_COUNT_EXCEEDED(BAD_REQUEST, "상품 이미지 개수가 최대 5개를 초과했습니다."),
 
   // Unauthorized:401:인증이슈
 

--- a/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
@@ -52,6 +52,12 @@ public class ProductServiceImpl implements ProductService {
   public ProductCreateResponseDto createProduct(ProductCreateRequestDto requestDto,
       List<MultipartFile> productImages, Long memberId) {
 
+    // 상품 이미지 개수 초과 판별
+    int size = productImages.size();
+    if (size > 5) {
+      throw CustomException.from(ExceptionCode.FILE_COUNT_EXCEEDED);
+    }
+
     // 존재하는 회원인지 판별
     Member member = findMember(memberId);
 


### PR DESCRIPTION
- 상품 이미지를 최대 5개까지 받을 수 있도록 설정

## #️⃣연관된 이슈
- 이슈 번호: #26

## 작업 내용
- 상품 이미지 최대 첨부 개수를 5개로 설정하고, 초과하면 CustomExceptionHandler로 예외를 처리합니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
