### PR TITLE
✨[#37]이메일, 인증코드 redis 저장

### DIFF
--- a/goodsending/src/main/java/com/goodsending/member/controller/MailController.java
+++ b/goodsending/src/main/java/com/goodsending/member/controller/MailController.java
@@ -1,5 +1,6 @@
 package com.goodsending.member.controller;
 
+import com.goodsending.member.dto.request.MailRequestDto;
 import com.goodsending.member.service.MailService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.mail.MessagingException;
@@ -8,8 +9,8 @@ import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -38,8 +39,8 @@ public class MailController {
    */
   @Operation(summary = "인증코드 발송 기능", description = "이메일 중복검사 후 인증코드 발송")
   @PostMapping("/members/sendMail")
-  public ResponseEntity<String> sendCode(@RequestParam @Valid String email)
+  public ResponseEntity<String> sendCode(@RequestBody @Valid MailRequestDto mailRequestDto)
       throws MessagingException, UnsupportedEncodingException {
-    return mailService.sendCode(email);
+    return mailService.sendCode(mailRequestDto);
   }
 }

--- a/goodsending/src/main/java/com/goodsending/member/dto/request/MailRequestDto.java
+++ b/goodsending/src/main/java/com/goodsending/member/dto/request/MailRequestDto.java
@@ -1,0 +1,13 @@
+package com.goodsending.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class MailRequestDto {
+
+  @NotBlank(message = "이메일이 입력되지 않았습니다.")
+  @Email
+  private String email;
+}

--- a/goodsending/src/main/java/com/goodsending/member/repository/SaveMailAndCodeRepository.java
+++ b/goodsending/src/main/java/com/goodsending/member/repository/SaveMailAndCodeRepository.java
@@ -1,0 +1,14 @@
+package com.goodsending.member.repository;
+
+import com.goodsending.global.redis.RedisRepository;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SaveMailAndCodeRepository extends RedisRepository<String, String> {
+  private static final String PREFIX = "email:code:";
+
+  public SaveMailAndCodeRepository(RedisTemplate<String, String> redisTemplate) {
+    super(PREFIX, redisTemplate);
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/member/service/MailService.java
+++ b/goodsending/src/main/java/com/goodsending/member/service/MailService.java
@@ -52,19 +52,19 @@ public class MailService {
    */
   public ResponseEntity<String> sendCode(MailRequestDto mailRequestDto) throws MessagingException, UnsupportedEncodingException {
 
-      // 이메일 중복 확인
-      Optional<Member> checkEmail = memberRepository.findByEmail(mailRequestDto.getEmail());
-      if (checkEmail.isEmpty()) {
-        String code = this.createCode();
+    // 이메일 중복 확인
+    Optional<Member> checkEmail = memberRepository.findByEmail(mailRequestDto.getEmail());
+    if (checkEmail.isPresent()) {
+      throw CustomException.from(ExceptionCode.EMAIL_ALREADY_EXISTS);
+    }
+    String code = this.createCode();
 
-        // redis 저장 (5분 동안 유효)
-        saveMailAndCodeRepository.setValue(mailRequestDto.getEmail(), code, Duration.ofMinutes(5));
+    // redis 저장 (5분 동안 유효)
+    saveMailAndCodeRepository.setValue(mailRequestDto.getEmail(), code, Duration.ofMinutes(5));
 
-        // 인증코드 메일 전송
-        createMail(mailRequestDto.getEmail(), code);
-      } else {
-        throw CustomException.from(ExceptionCode.EMAIL_ALREADY_EXISTS);
-      }
+    // 인증코드 메일 전송
+    createMail(mailRequestDto.getEmail(), code);
+
     return ResponseEntity.ok("인증코드 전송 완료");
   }
 

--- a/goodsending/src/main/java/com/goodsending/member/service/MailService.java
+++ b/goodsending/src/main/java/com/goodsending/member/service/MailService.java
@@ -2,8 +2,10 @@ package com.goodsending.member.service;
 
 import com.goodsending.global.exception.CustomException;
 import com.goodsending.global.exception.ExceptionCode;
+import com.goodsending.member.dto.request.MailRequestDto;
 import com.goodsending.member.entity.Member;
 import com.goodsending.member.repository.MemberRepository;
+import com.goodsending.member.repository.SaveMailAndCodeRepository;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
@@ -11,6 +13,7 @@ import jakarta.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,7 @@ public class MailService {
 
   private final JavaMailSender mailSender;
   private final MemberRepository memberRepository;
+  private final SaveMailAndCodeRepository saveMailAndCodeRepository;
 
   @Value("${spring.mail.username}")
   private String fromEmail;
@@ -46,18 +50,18 @@ public class MailService {
    * @return 인증완료 문구를 반환합니다.
    * @author : 이아람
    */
-  public ResponseEntity<String> sendCode(String email) throws MessagingException, UnsupportedEncodingException {
+  public ResponseEntity<String> sendCode(MailRequestDto mailRequestDto) throws MessagingException, UnsupportedEncodingException {
 
       // 이메일 중복 확인
-      Optional<Member> checkEmail = memberRepository.findByEmail(email);
+      Optional<Member> checkEmail = memberRepository.findByEmail(mailRequestDto.getEmail());
       if (checkEmail.isEmpty()) {
         String code = this.createCode();
 
-        // DB 저장
-        Member member = Member.from(email, code);
-        memberRepository.save(member);
+        // redis 저장 (5분 동안 유효)
+        saveMailAndCodeRepository.setValue(mailRequestDto.getEmail(), code, Duration.ofMinutes(5));
+
         // 인증코드 메일 전송
-        createMail(email, code);
+        createMail(mailRequestDto.getEmail(), code);
       } else {
         throw CustomException.from(ExceptionCode.EMAIL_ALREADY_EXISTS);
       }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #37

## 작업 내용
- 회원가입 시 인증코드 요청하면 이메일, 인증코드가 redis에 5분 동안 임시 저장됩니다. 

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
