### PR TITLE
✨ [#39] 자동 낙찰자 선정 후 주문 생성

### DIFF
--- a/goodsending/src/main/java/com/goodsending/bid/entity/Bid.java
+++ b/goodsending/src/main/java/com/goodsending/bid/entity/Bid.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @Date : 2024. 07. 25.
@@ -48,6 +49,7 @@ public class Bid extends BaseEntity {
   @Column(name = "use_point", nullable = true)
   private Integer usePoint;
 
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = true)
   private BidStatus status;

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
@@ -3,6 +3,12 @@ package com.goodsending.bid.repository;
 import com.goodsending.bid.entity.Bid;
 import java.util.List;
 
+/**
+ * @Date : 2024. 08. 01.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
 public interface BidQueryDslRepository {
   List<Bid> findByProductId(Long productId);
 }

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
@@ -1,0 +1,8 @@
+package com.goodsending.bid.repository;
+
+import com.goodsending.bid.entity.Bid;
+import java.util.List;
+
+public interface BidQueryDslRepository {
+  List<Bid> findByProductId(Long productId);
+}

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
@@ -9,6 +9,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * @Date : 2024. 08. 01.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
 @Repository
 @RequiredArgsConstructor
 public class BidQueryDslRepositoryImpl implements BidQueryDslRepository {

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.goodsending.bid.repository;
+
+import com.goodsending.bid.entity.Bid;
+import com.goodsending.bid.entity.QBid;
+import com.goodsending.member.entity.QMember;
+import com.goodsending.product.entity.QProduct;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BidQueryDslRepositoryImpl implements BidQueryDslRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Bid> findByProductId(Long productId) {
+    QBid bid = QBid.bid;
+    return queryFactory
+            .selectFrom(bid)
+            .innerJoin(bid.product, QProduct.product).fetchJoin()
+            .innerJoin(bid.member, QMember.member).fetchJoin()
+            .where(bid.product.id.eq(productId))
+            .orderBy(bid.price.desc())
+            .fetch();
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/bid/repository/ProductBidPriceMaxRepository.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/ProductBidPriceMaxRepository.java
@@ -1,6 +1,7 @@
 package com.goodsending.bid.repository;
 
 import com.goodsending.global.redis.RedisRepository;
+import java.time.Duration;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +13,8 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public class ProductBidPriceMaxRepository extends RedisRepository<Long, Integer> {
-  private final static String KEY_PREFIX = "PRODUCT_BID_PRICE_MAX:";
+  public final static String KEY_PREFIX = "PRODUCT_BID_PRICE_MAX:";
+  private static final int BID_EXTENSION_MINUTES = 5;
 
   public ProductBidPriceMaxRepository(RedisTemplate<String, Integer> redisTemplate) {
     super(KEY_PREFIX, redisTemplate);
@@ -20,5 +22,9 @@ public class ProductBidPriceMaxRepository extends RedisRepository<Long, Integer>
 
   public boolean isBidPriceMaxGreaterOrEqualsThan(Long key, Integer amount){
     return super.getValueByKey(key) >= amount;
+  }
+
+  public void setValueWithDuration(Long key, Integer value) {
+    super.setValue(key, value, Duration.ofMinutes(BID_EXTENSION_MINUTES));
   }
 }

--- a/goodsending/src/main/java/com/goodsending/bid/service/BidFacadeImpl.java
+++ b/goodsending/src/main/java/com/goodsending/bid/service/BidFacadeImpl.java
@@ -27,7 +27,6 @@ public class BidFacadeImpl implements BidFacade {
   private final BidService bidService;
   private final ProductBidPriceMaxRepository productBidPriceMaxRepository;
   private final SimpMessagingTemplate messagingTemplate;
-  private static final int BID_EXTENSION_MINUTES = 5;
 
   @Override
   public BidWithDurationResponse create(Long memberId, BidRequest request, LocalDateTime now)
@@ -37,8 +36,7 @@ public class BidFacadeImpl implements BidFacade {
         BidResponse bidResponse = bidService.create(memberId, request, now);
 
         // 현재 최고 금액을 업데이트 해준다.
-        productBidPriceMaxRepository.setValue(
-            request.productId(), request.bidPrice(), Duration.ofMinutes(BID_EXTENSION_MINUTES));
+        productBidPriceMaxRepository.setValueWithDuration(request.productId(), request.bidPrice());
 
         // 경매 마감까지 남은 시간: 업데이트 메시지를 보낸다.
         Duration remainingExpiration = productBidPriceMaxRepository.getRemainingExpiration(

--- a/goodsending/src/main/java/com/goodsending/global/config/RedisConfig.java
+++ b/goodsending/src/main/java/com/goodsending/global/config/RedisConfig.java
@@ -1,15 +1,18 @@
 package com.goodsending.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
  * @Date : 2024. 07. 27.
@@ -30,6 +33,33 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
+  }
+
+
+  /**
+   * RedisMessageListenerContainer의 기본 Executor: SimpleAsyncTaskExecutor
+   * <p>
+   * SimpleAsyncTaskExecutor 는 사용될 때 마다, 새로운 스레드를 만들어서 run()하기 때문에
+   * <p>
+   * Redis에서 이벤트가 수신될 때 마다 새로운 스레드가 만들어진다.
+   *
+   * @return
+   */
+  @Bean(name = "redisMessageTaskExecutor")
+  public Executor redisMessageTaskExecutor() {
+    ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+    threadPoolTaskExecutor.setCorePoolSize(2);
+    threadPoolTaskExecutor.setMaxPoolSize(4);
+    return threadPoolTaskExecutor;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(redisConnectionFactory);
+    container.setTaskExecutor(redisMessageTaskExecutor());
+    return container;
   }
 
   @Bean(name = "integerRedisTemplate")

--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -44,6 +44,7 @@ public enum ExceptionCode {
   USER_NOT_FOUND(NOT_FOUND, "유저 개체를 찾지 못했습니다."),
   PRODUCTIMAGE_NOT_FOUND(NOT_FOUND, "경매 상품 이미지를 찾지 못했습니다."),
   LIKE_NOT_FOUND(NOT_FOUND, "찜 개체를 찾지 못했습니다."),
+  BID_NOT_FOUND(NOT_FOUND, "입찰 개체를 찾지 못했습니다."),
   STOMP_HEADER_ACCESSOR_NOT_FOUND_EXCEPTION(NOT_FOUND, "메시지에서 STOMP 헤더 접근자를 가져오지 못했습니다."),
 
   // CONFLICT:409:충돌

--- a/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
@@ -1,0 +1,81 @@
+package com.goodsending.global.redis.handler;
+
+import com.goodsending.bid.entity.Bid;
+import com.goodsending.bid.repository.BidQueryDslRepository;
+import com.goodsending.bid.type.BidStatus;
+import com.goodsending.global.exception.CustomException;
+import com.goodsending.global.exception.ExceptionCode;
+import com.goodsending.member.entity.Member;
+import com.goodsending.order.entity.Order;
+import com.goodsending.order.repository.OrderRepository;
+import com.goodsending.product.entity.Product;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("bidPriceMaxKeyExpirationHandler")
+@RequiredArgsConstructor
+public class BidPriceMaxKeyExpirationHandler implements RedisMessageHandler {
+  private final BidQueryDslRepository bidQueryDslRepository;
+  private final OrderRepository orderRepository;
+
+  @Override
+  @Transactional
+  public void handle(String message) {
+    long productId = Long.parseLong(message.split(":")[1]);
+    List<Bid> bids = bidQueryDslRepository.findByProductId(productId);
+    if(bids.isEmpty()) throw CustomException.from(ExceptionCode.BID_NOT_FOUND);
+
+    setProduct(bids);
+    handlerBids(bids);
+  }
+
+  private void setProduct(List<Bid> bids) {
+    Product product = bids.get(0).getProduct();
+    product.setBiddingCount((long) bids.size());
+    product.setDynamicEndDateTime(LocalDateTime.now());
+  }
+
+  private void handlerBids(List<Bid> bids) {
+    // 입찰금이 제일 큰 사람은 낙찰 성공해서 주문이 진행된다.
+    Bid winningBid = bids.get(0);
+    saveOrderByBid(winningBid);
+    winningBid.setStatus(BidStatus.SUCCESSFUL);
+
+    // 나머지 입찰자들에 대한 환불 처리
+    Map<Member, Integer> cashRefunds = new HashMap<>();
+    Map<Member, Integer> pointRefunds = new HashMap<>();
+
+    for (int i = 1; i < bids.size(); i++) {
+      Bid bid = bids.get(i);
+      bid.setStatus(BidStatus.FAILED);
+      
+      int price = (bid.getPrice() != null) ? bid.getPrice() : 0;
+      int usePoint = (bid.getUsePoint() != null) ? bid.getUsePoint() : 0;
+      int refundCash = price - usePoint;
+
+      Member member = bid.getMember();
+      cashRefunds.merge(member, refundCash, Integer::sum);
+      pointRefunds.merge(member, usePoint, Integer::sum);
+    }
+
+    // Cash와 Point를 한 번에 업데이트
+    for (Map.Entry<Member, Integer> entry : cashRefunds.entrySet()) {
+      Member member = entry.getKey();
+      member.addCash(entry.getValue());
+    }
+
+    for (Map.Entry<Member, Integer> entry : pointRefunds.entrySet()) {
+      Member member = entry.getKey();
+      member.addPoint(entry.getValue());
+    }
+  }
+
+  private Order saveOrderByBid(Bid bid) {
+    return orderRepository.save(Order.from(bid));
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/global/redis/handler/RedisMessageHandler.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/handler/RedisMessageHandler.java
@@ -1,5 +1,11 @@
 package com.goodsending.global.redis.handler;
 
+/**
+ * @Date : 2024. 08. 01.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
 public interface RedisMessageHandler {
   void handle(String message);
 }

--- a/goodsending/src/main/java/com/goodsending/global/redis/handler/RedisMessageHandler.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/handler/RedisMessageHandler.java
@@ -1,0 +1,5 @@
+package com.goodsending.global.redis.handler;
+
+public interface RedisMessageHandler {
+  void handle(String message);
+}

--- a/goodsending/src/main/java/com/goodsending/global/redis/listener/RedisKeyExpirationListener.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/listener/RedisKeyExpirationListener.java
@@ -1,0 +1,53 @@
+package com.goodsending.global.redis.listener;
+
+import com.goodsending.bid.repository.ProductBidPriceMaxRepository;
+import com.goodsending.global.redis.handler.RedisMessageHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author : jieun
+ * @Date : 2024. 07. 31.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Component
+@Slf4j
+public class RedisKeyExpirationListener extends KeyExpirationEventMessageListener {
+  private final ApplicationContext applicationContext;
+
+  public RedisKeyExpirationListener(RedisMessageListenerContainer listenerContainer,
+      ApplicationContext applicationContext) {
+    super(listenerContainer);
+    this.applicationContext = applicationContext;
+  }
+
+  /**
+   * 만료된 키에 대한 처리를 수행합니다.
+   *
+   * @param message redis key
+   * @param pattern __keyevent@*__:expired
+   */
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    String key = message.toString();
+    log.info("Expired key: {}", key);
+
+    RedisMessageHandler handler = null;
+    if(key.startsWith(ProductBidPriceMaxRepository.KEY_PREFIX)){
+      handler = this.applicationContext.getBean(
+          "bidPriceMaxKeyExpirationHandler", RedisMessageHandler.class);
+    }
+
+    if(handler != null){
+      handler.handle(key);
+    }
+  }
+
+
+}
+

--- a/goodsending/src/main/java/com/goodsending/member/entity/Member.java
+++ b/goodsending/src/main/java/com/goodsending/member/entity/Member.java
@@ -16,11 +16,13 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@EqualsAndHashCode(of = "memberId")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
 public class Member extends BaseEntity {
@@ -97,7 +99,7 @@ public class Member extends BaseEntity {
   public void cashUpdate(Integer cash) {
     this.cash = cash;
   }
-    
+
   public boolean isCashGreaterOrEqualsThan(Integer amount){
     if (this.cash == null || amount == null) {
       return false;
@@ -112,19 +114,35 @@ public class Member extends BaseEntity {
     return this.point >= amount;
   }
 
+  public void addCash(int cash) {
+    if(this.cash == null){
+      this.cash = cash;
+      return;
+    }
+    this.cash += cash;
+  }
+
+  public void addPoint(int point){
+    if(this.point == null){
+      this.point = point;
+      return;
+    }
+    this.point += point;
+  }
+
   public void deductCash(Integer amount) {
-    if(this.cash == null) return;
     if(!this.isCashGreaterOrEqualsThan(amount)){
       throw CustomException.from(ExceptionCode.USER_CASH_MUST_BE_POSITIVE);
     }
+
     this.cash -= amount;
   }
 
   public void deductPoint(Integer amount) {
-    if(this.point == null) return;
     if (!this.isPointGreaterOrEqualsThan(amount)) {
       throw CustomException.from(ExceptionCode.USER_POINT_MUST_BE_POSITIVE);
     }
+
     this.point -= amount;
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * @Date : 2024. 07. 25.
+ * @Date : 2024. 07. 30.
  * @Team : GoodsEnding
  * @author : jieun
  * @Project : goodsending-be :: goodsending

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -1,0 +1,60 @@
+package com.goodsending.order.entity;
+
+import com.goodsending.bid.entity.Bid;
+import com.goodsending.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2024. 07. 25.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+  @Id
+  private Long id;
+
+  @Column(name = "receiver_cell_number", nullable = true)
+  private String receiverCellNumber;
+
+  @Column(name = "receiver_name", nullable = true)
+  private String receiverName;
+
+  @Column(name = "receiver_address", nullable = true)
+  private String receiverAddress;
+
+  @Column(name = "delivery_date_time", nullable = true)
+  private LocalDateTime deliveryDateTime;
+
+  @Column(name = "confirmed_date_time", nullable = true)
+  private LocalDateTime confirmedDateTime;
+
+  @MapsId
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id")
+  private Bid bid;
+
+  private Order(Bid bid) {
+    this.bid = bid;
+  }
+
+  public static Order from(Bid bid) {
+    return new Order(bid);
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
@@ -3,6 +3,12 @@ package com.goodsending.order.repository;
 import com.goodsending.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * @Date : 2024. 08. 01.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.goodsending.order.repository;
+
+import com.goodsending.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/goodsending/src/main/java/com/goodsending/product/entity/Product.java
+++ b/goodsending/src/main/java/com/goodsending/product/entity/Product.java
@@ -4,7 +4,18 @@ import com.goodsending.global.entity.BaseEntity;
 import com.goodsending.member.entity.Member;
 import com.goodsending.product.dto.request.ProductCreateRequestDto;
 import com.goodsending.product.type.AuctionTime;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +23,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "products")
@@ -40,6 +52,7 @@ public class Product extends BaseEntity {
   private LocalDateTime maxEndDateTime;
 
   // dynamicEndDateTime은 낙찰자가 정해졌을 때 입력되는 값이다.
+  @Setter
   @Column(name = "dynamic_end_date_time")
   private LocalDateTime dynamicEndDateTime;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #39 

## 작업 내용
- 낙찰자 자동 선정 후 주문 생성
   * 입찰 후 5분동안 추가 입찰이 없으면 마지막 입찰자가 낙찰자가 됩니다.
   * 입찰의 상태가 낙찰자는 SUCCESS, 낙찰자를 제외한 입찰은 FAIL로 업데이트 됩니다.
   * 낙찰자의 주문이 자동 생성됩니다.
   * 낙찰자를 제외한 유저는 환불처리(포인트, 캐시) 됩니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석)를 업데이트했습니다.

### 기타 - 선택 (추가 설명, 스크린샷 등)
