### PR TITLE
🐛 [#53] Member @EqualsAndHashCode(callSuper = false) 추가

### DIFF
--- a/goodsending/src/main/java/com/goodsending/member/entity/Member.java
+++ b/goodsending/src/main/java/com/goodsending/member/entity/Member.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@EqualsAndHashCode(of = "memberId")
+@EqualsAndHashCode(callSuper = false, of = "memberId")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
 public class Member extends BaseEntity {


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #53

## 작업 내용
- 상속받은 클래스에 @EqualsAndHashCode 사용시 

![image](https://github.com/user-attachments/assets/ba9fad05-a74f-47c9-9920-33bb4c707db2)

경고가 뜬다.

@EqualsAndHashCode(callSuper = true) 어노테이션을 붙여주지 않으면, 부모 클래스의 필드는 제외하고 EqualsAndHashCode를 생성해서 발생하는 warning이다.

자식 클래스의 필드만을 포함하고 싶기 때문에 @EqualsAndHashCode(callSuper = false)를 붙여 warning이 뜨지 않게 해주었다..
