### PR TITLE
✨ [#52] 주문 상품 수신자 정보 업데이트

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -2,6 +2,7 @@ package com.goodsending.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
@@ -10,7 +11,6 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.atn.SemanticContext.OR;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -40,6 +40,7 @@ public enum ExceptionCode {
   INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
 
   // FORBIDDEN:403:권한이슈
+  RECEIVER_ID_MISMATCH(FORBIDDEN, "수신자만이 수신 정보를 변경할 수 있습니다."),
 
   // NOT_FOUND:404:자원없음
   PRODUCT_NOT_FOUND(NOT_FOUND, "경매 상품 개체를 찾지 못했습니다."),
@@ -48,6 +49,7 @@ public enum ExceptionCode {
   PRODUCTIMAGE_NOT_FOUND(NOT_FOUND, "경매 상품 이미지를 찾지 못했습니다."),
   LIKE_NOT_FOUND(NOT_FOUND, "찜 개체를 찾지 못했습니다."),
   BID_NOT_FOUND(NOT_FOUND, "입찰 개체를 찾지 못했습니다."),
+  ORDER_NOT_FOUND(NOT_FOUND, "주문 개체를 찾지 못했습니다."),
   STOMP_HEADER_ACCESSOR_NOT_FOUND_EXCEPTION(NOT_FOUND, "메시지에서 STOMP 헤더 접근자를 가져오지 못했습니다."),
   CODE_EXPIRED_OR_INVALID(NOT_FOUND, "인증 코드가 만료되었거나 존재하지 않습니다."),
 

--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -1,0 +1,34 @@
+package com.goodsending.order.controller;
+
+import com.goodsending.global.security.anotation.MemberId;
+import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+  private final OrderService orderService;
+
+  @Operation(summary = "주문 상품 수신자 정보 업데이트",
+      description = "주문 상품 수신자 정보(수신자명, 수신자연락처, 수신자 주소)를 업데이트 합니다.")
+  @PutMapping("/receiver-info")
+  public ResponseEntity<ReceiverInfoResponse> updateReceiverInfo(
+      @MemberId Long memberId, @RequestBody ReceiverInfoRequest request){
+    return ResponseEntity.ok(orderService.updateReceiverInfo(memberId, request));
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @Date : 2024. 08. 02.
  * @Team : GoodsEnding
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Project : goodsending-be :: goodsending
  */
 @RequiredArgsConstructor
@@ -24,6 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
   private final OrderService orderService;
 
+  /**
+   *
+   * @param memberId 로그인 유저 아이디
+   * @param request 수신자명, 수신자연락처, 수신자 주소를 받습니다.
+   * @return 저장된 order 정보를 반환합니다.
+   * @author : jieun(je-pa)
+   */
   @Operation(summary = "주문 상품 수신자 정보 업데이트",
       description = "주문 상품 수신자 정보(수신자명, 수신자연락처, 수신자 주소)를 업데이트 합니다.")
   @PutMapping("/receiver-info")

--- a/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Date : 2024. 08. 02.
  * @Team : GoodsEnding
  * @Project : goodsending-be :: goodsending

--- a/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
@@ -1,0 +1,29 @@
+package com.goodsending.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * @author : jieun
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+public record ReceiverInfoRequest(
+
+    @NotNull
+    Long orderId,
+
+    @NotBlank
+    String receiverName,
+
+    @NotBlank
+    @ValidPhoneNumber
+    String receiverCellNumber,
+
+    @NotBlank
+    String receiverAddress
+
+) {
+
+}

--- a/goodsending/src/main/java/com/goodsending/order/dto/request/ValidPhoneNumber.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/request/ValidPhoneNumber.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Date : 2024. 08. 03.
  * @Team : GoodsEnding
  * @Project : goodsending-be :: goodsending

--- a/goodsending/src/main/java/com/goodsending/order/dto/request/ValidPhoneNumber.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/request/ValidPhoneNumber.java
@@ -1,0 +1,36 @@
+package com.goodsending.order.dto.request;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * @author : jieun
+ * @Date : 2024. 08. 03.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+@Pattern(regexp = "^01[016789]-(?:\\d{3}|\\d{4})-\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+public @interface ValidPhoneNumber {
+
+  String message() default "올바른 휴대폰 번호 형식이 아닙니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
@@ -4,7 +4,7 @@ import com.goodsending.order.entity.Order;
 import lombok.Builder;
 
 /**
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Date : 2024. 08. 02.
  * @Team : GoodsEnding
  * @Project : goodsending-be :: goodsending

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
@@ -11,6 +11,10 @@ import lombok.Builder;
  */
 @Builder
 public record ReceiverInfoResponse(
+    Long orderId,
+
+    Long bidderId,
+
     String receiverName,
 
     String receiverCellNumber,
@@ -20,6 +24,8 @@ public record ReceiverInfoResponse(
 ) {
     public static ReceiverInfoResponse from(Order order) {
         return ReceiverInfoResponse.builder()
+            .orderId(order.getId())
+            .bidderId(order.getBid().getMember().getMemberId())
             .receiverName(order.getReceiverName())
             .receiverCellNumber(order.getReceiverCellNumber())
             .receiverAddress(order.getReceiverAddress())

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/ReceiverInfoResponse.java
@@ -1,0 +1,28 @@
+package com.goodsending.order.dto.response;
+
+import com.goodsending.order.entity.Order;
+import lombok.Builder;
+
+/**
+ * @author : jieun
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Builder
+public record ReceiverInfoResponse(
+    String receiverName,
+
+    String receiverCellNumber,
+
+    String receiverAddress
+
+) {
+    public static ReceiverInfoResponse from(Order order) {
+        return ReceiverInfoResponse.builder()
+            .receiverName(order.getReceiverName())
+            .receiverCellNumber(order.getReceiverCellNumber())
+            .receiverAddress(order.getReceiverAddress())
+            .build();
+    }
+}

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -6,6 +6,8 @@ import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.type.OrderStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -47,6 +49,7 @@ public class Order extends BaseEntity {
   @Column(name = "confirmed_date_time", nullable = true)
   private LocalDateTime confirmedDateTime;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = true)
   private OrderStatus status;
 

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -2,6 +2,8 @@ package com.goodsending.order.entity;
 
 import com.goodsending.bid.entity.Bid;
 import com.goodsending.global.entity.BaseEntity;
+import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.type.OrderStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -45,6 +47,9 @@ public class Order extends BaseEntity {
   @Column(name = "confirmed_date_time", nullable = true)
   private LocalDateTime confirmedDateTime;
 
+  @Column(name = "status", nullable = true)
+  private OrderStatus status;
+
   @MapsId
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id")
@@ -56,5 +61,17 @@ public class Order extends BaseEntity {
 
   public static Order from(Bid bid) {
     return new Order(bid);
+  }
+
+  public boolean isReceiverId(Long memberId){
+    return this.bid.getMember().getMemberId().equals(memberId);
+  }
+
+  public Order updateReceiverInfo(ReceiverInfoRequest request){
+    this.receiverAddress = request.receiverAddress();
+    this.receiverName = request.receiverName();
+    this.receiverCellNumber = request.receiverCellNumber();
+    this.status = OrderStatus.PENDING;
+    return this;
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 /**
  * @Date : 2024. 07. 30.
  * @Team : GoodsEnding
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Project : goodsending-be :: goodsending
  */
 @Entity

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
@@ -1,0 +1,8 @@
+package com.goodsending.order.repository;
+
+import com.goodsending.order.entity.Order;
+import java.util.Optional;
+
+public interface OrderQueryDslRepository {
+  Optional<Order> findOrderWithBidById(Long orderId);
+}

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
@@ -3,6 +3,12 @@ package com.goodsending.order.repository;
 import com.goodsending.order.entity.Order;
 import java.util.Optional;
 
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 03.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
 public interface OrderQueryDslRepository {
   Optional<Order> findOrderWithBidById(Long orderId);
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
@@ -9,6 +9,12 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 03.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
 @Repository
 @RequiredArgsConstructor
 public class OrderQueryDslRepositoryImpl implements  OrderQueryDslRepository {

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.goodsending.order.repository;
+
+import static com.goodsending.bid.entity.QBid.bid;
+import static com.goodsending.order.entity.QOrder.order;
+
+import com.goodsending.order.entity.Order;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryDslRepositoryImpl implements  OrderQueryDslRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<Order> findOrderWithBidById(Long orderId) {
+    return Optional.ofNullable(queryFactory
+        .selectFrom(order)
+        .leftJoin(order.bid, bid).fetchJoin()
+        .where(order.id.eq(orderId))
+        .fetchOne());
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /**
  * @Date : 2024. 08. 01.
  * @Team : GoodsEnding
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Project : goodsending-be :: goodsending
  */
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryDslRepository {

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author : jieun
  * @Project : goodsending-be :: goodsending
  */
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryDslRepository {
 
 }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -4,12 +4,19 @@ import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
 
 /**
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Date : 2024. 08. 02.
  * @Team : GoodsEnding
  * @Project : goodsending-be :: goodsending
  */
 public interface OrderService {
 
+  /**
+   * 낙찰자가 주문에 대한 배송 정보를 입력합니다.
+   * @param memberId 로그인 유저 아이디
+   * @param request 배송지 주소, 연락처, 수신자명
+   * @return 저장된 주문 정보
+   * @author : jieun(je-pa)
+   */
   ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request);
 }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -1,0 +1,15 @@
+package com.goodsending.order.service;
+
+import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.ReceiverInfoResponse;
+
+/**
+ * @author : jieun
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+public interface OrderService {
+
+  ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request);
+}

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
@@ -25,7 +25,7 @@ public class OrderServiceImpl implements OrderService{
   @Override
   @Transactional
   public ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request) {
-    Order order = findOrderById(request.orderId());
+    Order order = findOrderWithBidById(request.orderId());
 
     if(!order.isReceiverId(memberId)) {
       throw CustomException.from(ExceptionCode.RECEIVER_ID_MISMATCH);
@@ -34,8 +34,8 @@ public class OrderServiceImpl implements OrderService{
     return ReceiverInfoResponse.from(order.updateReceiverInfo(request));
   }
 
-  private Order findOrderById(Long orderId) {
-    return orderRepository.findById(orderId).orElseThrow(
+  private Order findOrderWithBidById(Long orderId) {
+    return orderRepository.findOrderWithBidById(orderId).orElseThrow(
         () -> CustomException.from(ExceptionCode.ORDER_NOT_FOUND)
     );
   }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
@@ -1,0 +1,42 @@
+package com.goodsending.order.service;
+
+import com.goodsending.global.exception.CustomException;
+import com.goodsending.global.exception.ExceptionCode;
+import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.entity.Order;
+import com.goodsending.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @author : jieun
+ * @Project : goodsending-be :: goodsending
+ */
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService{
+
+  private final OrderRepository orderRepository;
+
+  @Override
+  @Transactional
+  public ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request) {
+    Order order = findOrderById(request.orderId());
+
+    if(!order.isReceiverId(memberId)) {
+      throw CustomException.from(ExceptionCode.RECEIVER_ID_MISMATCH);
+    }
+
+    return ReceiverInfoResponse.from(order.updateReceiverInfo(request));
+  }
+
+  private Order findOrderById(Long orderId) {
+    return orderRepository.findById(orderId).orElseThrow(
+        () -> CustomException.from(ExceptionCode.ORDER_NOT_FOUND)
+    );
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * @Date : 2024. 08. 02.
  * @Team : GoodsEnding
- * @author : jieun
+ * @author : jieun(je-pa)
  * @Project : goodsending-be :: goodsending
  */
 @Service
@@ -22,6 +22,13 @@ public class OrderServiceImpl implements OrderService{
 
   private final OrderRepository orderRepository;
 
+  /**
+   * 낙찰자가 주문에 대한 배송 정보를 입력합니다.
+   * @param memberId 로그인 유저 아이디
+   * @param request 배송지 주소, 연락처, 수신자명
+   * @return 저장된 주문 정보
+   * @author : jieun(je-pa)
+   */
   @Override
   @Transactional
   public ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request) {

--- a/goodsending/src/main/java/com/goodsending/order/type/OrderStatus.java
+++ b/goodsending/src/main/java/com/goodsending/order/type/OrderStatus.java
@@ -1,0 +1,17 @@
+package com.goodsending.order.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum OrderStatus {
+  CANCELLED("취소된"),
+  COMPLETED("완료된"),
+  SHIPPING("배송중"),
+  PENDING("배송전");
+
+  private final String name;
+
+  public String getName() {
+    return name;
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/order/type/OrderStatus.java
+++ b/goodsending/src/main/java/com/goodsending/order/type/OrderStatus.java
@@ -2,6 +2,12 @@ package com.goodsending.order.type;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
 @RequiredArgsConstructor
 public enum OrderStatus {
   CANCELLED("취소된"),


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #52 

## 작업 내용
- 낙찰자가 주문에 대한 배송 정보를 입력한다.

- 작업 상세 내용
  - 주문 배송 정보 업데이트
  - 낙찰자가 배송받을 배송지주소, 연락처, 수신자명 를 입력합니다.
  - 낙찰자(=수신자)만이 업데이트가 가능합니다.
  - 상태가 배송전(PENDING)으로 업데이트 됩니다.
  - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석)를 업데이트했습니다.