### PR TITLE
✨ [#67] 주문 배송 출발 처리

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -34,6 +34,7 @@ public enum ExceptionCode {
   MEMBER_ID_MISMATCH(BAD_REQUEST, "회원 아이디가 일치하지 않습니다."),
   CODE_EXPIRED_OR_INVALID(NOT_FOUND, "인증 코드가 만료되었거나 존재하지 않습니다."),
   BIDDER_ALREADY_EXIST(BAD_REQUEST, "입찰자가 이미 존재합니다."),
+  ORDER_IS_NOT_PENDING(BAD_REQUEST, "주문의 배송지 정보가 입력되어야 배송 출발이 가능합니다."),
 
   // Unauthorized:401:인증이슈
   MEMBER_PASSWORD_INCORRECT(UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
@@ -41,6 +42,7 @@ public enum ExceptionCode {
 
   // FORBIDDEN:403:권한이슈
   RECEIVER_ID_MISMATCH(FORBIDDEN, "수신자만이 수신 정보를 변경할 수 있습니다."),
+  SELLER_ID_MISMATCH(FORBIDDEN, "상품 판매자만이 수신 정보를 변경할 수 있습니다."),
 
   // NOT_FOUND:404:자원없음
   PRODUCT_NOT_FOUND(NOT_FOUND, "경매 상품 개체를 찾지 못했습니다."),

--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -3,10 +3,13 @@ package com.goodsending.order.controller;
 import com.goodsending.global.security.anotation.MemberId;
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.dto.response.UpdateShippingResponse;
 import com.goodsending.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,20 @@ public class OrderController {
   public ResponseEntity<ReceiverInfoResponse> updateReceiverInfo(
       @MemberId Long memberId, @RequestBody ReceiverInfoRequest request){
     return ResponseEntity.ok(orderService.updateReceiverInfo(memberId, request));
+  }
+
+  /**
+   * 판매자가 주문을 배송 출발 처리 합니다.
+   * @param memberId 로그인 유저 아이디 => 판매자 id
+   * @param orderId 주문 id
+   * @return 업데이트된 order 정보를 반환합니다.
+   * @author : jieun(je-pa)
+   */
+  @Operation(summary = "주문 배송 출발 처리",
+      description =  "판매자가 주문을 배송 출발 처리 합니다.")
+  @PutMapping("/{orderId}/delivery")
+  public ResponseEntity<UpdateShippingResponse> updateShipping(@MemberId Long memberId,
+      @PathVariable Long orderId){
+    return ResponseEntity.ok(orderService.updateShipping(memberId, orderId, LocalDateTime.now()));
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/UpdateShippingResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/UpdateShippingResponse.java
@@ -1,0 +1,42 @@
+package com.goodsending.order.dto.response;
+
+import com.goodsending.order.entity.Order;
+import com.goodsending.order.type.OrderStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Builder
+public record UpdateShippingResponse(
+    Long orderId,
+
+    Long sellerId,
+
+    String receiverName,
+
+    String receiverCellNumber,
+
+    String receiverAddress,
+
+    LocalDateTime deliveryDateTime,
+
+    OrderStatus status
+
+) {
+    public static UpdateShippingResponse from(Order order) {
+        return UpdateShippingResponse.builder()
+            .orderId(order.getId())
+            .sellerId(order.getBid().getProduct().getMember().getMemberId())
+            .receiverName(order.getReceiverName())
+            .receiverCellNumber(order.getReceiverCellNumber())
+            .receiverAddress(order.getReceiverAddress())
+            .deliveryDateTime(order.getDeliveryDateTime())
+            .status(order.getStatus())
+            .build();
+    }
+}

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -70,11 +70,28 @@ public class Order extends BaseEntity {
     return this.bid.getMember().getMemberId().equals(memberId);
   }
 
+  public boolean isSellerId(Long memberId){
+    return this.bid.getProduct().getMember().getMemberId().equals(memberId);
+  }
+
   public Order updateReceiverInfo(ReceiverInfoRequest request){
     this.receiverAddress = request.receiverAddress();
     this.receiverName = request.receiverName();
     this.receiverCellNumber = request.receiverCellNumber();
     this.status = OrderStatus.PENDING;
     return this;
+  }
+
+  public Order updateShipping(LocalDateTime deliveryDateTime){
+    this.status = OrderStatus.SHIPPING;
+    this.deliveryDateTime = deliveryDateTime;
+    return this;
+  }
+
+  public boolean isPending(){
+    return this.receiverCellNumber != null &&
+        this.receiverAddress != null &&
+        this.receiverName != null &&
+        this.status == OrderStatus.PENDING;
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
  */
 public interface OrderQueryDslRepository {
   Optional<Order> findOrderWithBidById(Long orderId);
+
+  Optional<Order> findOrderWithBidAndProductById(Long orderId);
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.goodsending.order.repository;
 
 import static com.goodsending.bid.entity.QBid.bid;
 import static com.goodsending.order.entity.QOrder.order;
+import static com.goodsending.product.entity.QProduct.product;
 
 import com.goodsending.order.entity.Order;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,6 +27,16 @@ public class OrderQueryDslRepositoryImpl implements  OrderQueryDslRepository {
     return Optional.ofNullable(queryFactory
         .selectFrom(order)
         .leftJoin(order.bid, bid).fetchJoin()
+        .where(order.id.eq(orderId))
+        .fetchOne());
+  }
+
+  @Override
+  public Optional<Order> findOrderWithBidAndProductById(Long orderId) {
+    return Optional.ofNullable(queryFactory
+        .selectFrom(order)
+        .innerJoin(order.bid, bid).fetchJoin()
+        .innerJoin(order.bid.product, product).fetchJoin()
         .where(order.id.eq(orderId))
         .fetchOne());
   }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.goodsending.order.service;
 
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.dto.response.UpdateShippingResponse;
+import java.time.LocalDateTime;
 
 /**
  * @author : jieun(je-pa)
@@ -19,4 +21,6 @@ public interface OrderService {
    * @author : jieun(je-pa)
    */
   ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request);
+
+  UpdateShippingResponse updateShipping(Long memberId, Long orderId, LocalDateTime now);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #67 

## 작업 내용
- 판매자가 주문 배송 출발 처리를 합니다.
  - 주문 상태를 배송 중으로 업데이트
  - 배송 정보 입력이 된 후 판매자가 배송출발을 진행합니다.
  - 배송일시가 업데이트 됩니다.
  - 취소된 주문은 배송 중으로 업데이트할 수 없습니다.
  - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
 
- api 요청 예시

```http
### 판매자가 주문 배송 출발 처리를 합니다.
PUT http://localhost:8080/api/orders/132/delivery
Content-Type: application/json
Authorization: Bearer {판매자 access token}
```

- response body 예시
```json
{
  "orderId": 132,
  "sellerId": 48,
  "receiverName": "박지은",
  "receiverCellNumber": "010-7777-7777",
  "receiverAddress": "ㅇㅇ시 ㅇㅇ동",
  "deliveryDateTime": "2024-08-05T17:40:47.876664",
  "status": "SHIPPING"
}
```
- orer 조회 sql
```sql
select
        o1_0.order_id,
        b1_0.(생략),
        p1_0.(생략),
        b1_0.(생략),
        o1_0.(생략)
    from
        orders o1_0 
    join
        bids b1_0 
            on b1_0.bid_id=o1_0.order_id 
    join
        products p1_0 
            on p1_0.product_id=b1_0.product_id 
    where
        o1_0.order_id=?
```

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석 등)를 업데이트했습니다.
