### PR TITLE
♻️ [#69] 주문 상품 수신자 정보 업데이트 api 수정

### DIFF
--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.goodsending.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,9 +34,11 @@ public class OrderController {
    */
   @Operation(summary = "주문 상품 수신자 정보 업데이트",
       description = "주문 상품 수신자 정보(수신자명, 수신자연락처, 수신자 주소)를 업데이트 합니다.")
-  @PutMapping("/receiver-info")
+  @PutMapping("/{orderId}/receiver-info")
   public ResponseEntity<ReceiverInfoResponse> updateReceiverInfo(
-      @MemberId Long memberId, @RequestBody ReceiverInfoRequest request){
-    return ResponseEntity.ok(orderService.updateReceiverInfo(memberId, request));
+      @MemberId Long memberId,
+      @PathVariable Long orderId,
+      @RequestBody ReceiverInfoRequest request){
+    return ResponseEntity.ok(orderService.updateReceiverInfo(memberId, orderId, request));
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/request/ReceiverInfoRequest.java
@@ -1,7 +1,6 @@
 package com.goodsending.order.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 /**
  * @author : jieun(je-pa)
@@ -10,9 +9,6 @@ import jakarta.validation.constraints.NotNull;
  * @Project : goodsending-be :: goodsending
  */
 public record ReceiverInfoRequest(
-
-    @NotNull
-    Long orderId,
 
     @NotBlank
     String receiverName,

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -18,5 +18,5 @@ public interface OrderService {
    * @return 저장된 주문 정보
    * @author : jieun(je-pa)
    */
-  ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request);
+  ReceiverInfoResponse updateReceiverInfo(Long memberId, Long orderId, ReceiverInfoRequest request);
 }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
@@ -31,8 +31,8 @@ public class OrderServiceImpl implements OrderService{
    */
   @Override
   @Transactional
-  public ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request) {
-    Order order = findOrderWithBidById(request.orderId());
+  public ReceiverInfoResponse updateReceiverInfo(Long memberId, Long orderId, ReceiverInfoRequest request) {
+    Order order = findOrderWithBidById(orderId);
 
     if(!order.isReceiverId(memberId)) {
       throw CustomException.from(ExceptionCode.RECEIVER_ID_MISMATCH);


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #69 

## 작업 내용
- api 명세서에 맞게 수정이 했습니다.
  - /api/orders/receiver-info -> /api/orders/{orderId}/receiver-info
- api 요청 예시

```http
###
PUT http://localhost:8080/api/orders/132/receiver-info
Content-Type: application/json
Authorization: Bearer {access token}
{
  "receiverName": "박지은",
  "receiverCellNumber": "010-7777-7777",
  "receiverAddress": "ㅇㅇ시 ㅇㅇ동"
}
```

- api 응답 예시

![image](https://github.com/user-attachments/assets/d075b401-44ac-4710-afe2-122b71c364e5)

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드)를 업데이트했습니다.
