### PR TITLE
✨ [#72] 거래 확정 기능

### DIFF
--- a/goodsending/src/main/java/com/goodsending/charge/entity/ChargeHistory.java
+++ b/goodsending/src/main/java/com/goodsending/charge/entity/ChargeHistory.java
@@ -1,0 +1,57 @@
+package com.goodsending.charge.entity;
+
+import com.goodsending.order.entity.Order;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2024. 08. 05.
+ * @Team : GoodsEnding
+ * @author : jieun(je-pa)
+ * @Project : goodsending-be :: goodsending
+ */
+@Entity
+@Getter
+@Table(name = "charge_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChargeHistory {
+
+  @Id
+  private Long id;
+
+  @Column(name = "price", nullable = false)
+  private int price;
+
+  @Column(name = "accumulated_price", nullable = false)
+  private int accumulatedPrice;
+
+  @MapsId
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "charge_id")
+  private Order order;
+
+  @Builder
+  private ChargeHistory(Order order, int price, int accumulatedPrice) {
+    this.order = order;
+    this.price = price;
+    this.accumulatedPrice = accumulatedPrice;
+  }
+
+  public static ChargeHistory of(Order order, int price, int accumulatedPrice) {
+    return ChargeHistory.builder()
+        .order(order)
+        .price(price)
+        .accumulatedPrice(accumulatedPrice)
+        .build();
+  }
+}

--- a/goodsending/src/main/java/com/goodsending/charge/repository/ChargeHistoryRepository.java
+++ b/goodsending/src/main/java/com/goodsending/charge/repository/ChargeHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.goodsending.charge.repository;
+
+import com.goodsending.charge.entity.ChargeHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChargeHistoryRepository extends JpaRepository<ChargeHistory, Long> {
+
+}

--- a/goodsending/src/main/java/com/goodsending/deposit/entity/Deposit.java
+++ b/goodsending/src/main/java/com/goodsending/deposit/entity/Deposit.java
@@ -68,4 +68,8 @@ public class Deposit {
         .status(DepositStatus.UNRETURNED)
         .build();
   }
+
+  public void processReturn(){
+    this.status = DepositStatus.RETURNED;
+  }
 }

--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -35,6 +35,7 @@ public enum ExceptionCode {
   CODE_EXPIRED_OR_INVALID(NOT_FOUND, "인증 코드가 만료되었거나 존재하지 않습니다."),
   BIDDER_ALREADY_EXIST(BAD_REQUEST, "입찰자가 이미 존재합니다."),
   ORDER_IS_NOT_PENDING(BAD_REQUEST, "주문의 배송지 정보가 입력되어야 배송 출발이 가능합니다."),
+  ORDER_IS_NOT_SHIPPING(BAD_REQUEST, "배송이 출발한 후에 주문 확정이 가능합니다."),
 
   // Unauthorized:401:인증이슈
   MEMBER_PASSWORD_INCORRECT(UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),

--- a/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
+++ b/goodsending/src/main/java/com/goodsending/global/exception/ExceptionCode.java
@@ -34,6 +34,7 @@ public enum ExceptionCode {
   MEMBER_ID_MISMATCH(BAD_REQUEST, "회원 아이디가 일치하지 않습니다."),
   CODE_EXPIRED_OR_INVALID(NOT_FOUND, "인증 코드가 만료되었거나 존재하지 않습니다."),
   BIDDER_ALREADY_EXIST(BAD_REQUEST, "입찰자가 이미 존재합니다."),
+  ORDER_IS_NOT_PENDING(BAD_REQUEST, "주문의 배송지 정보가 입력되어야 배송 출발이 가능합니다."),
 
   // Unauthorized:401:인증이슈
   MEMBER_PASSWORD_INCORRECT(UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
@@ -41,6 +42,7 @@ public enum ExceptionCode {
 
   // FORBIDDEN:403:권한이슈
   RECEIVER_ID_MISMATCH(FORBIDDEN, "수신자만이 수신 정보를 변경할 수 있습니다."),
+  SELLER_ID_MISMATCH(FORBIDDEN, "상품 판매자만이 수신 정보를 변경할 수 있습니다."),
 
   // NOT_FOUND:404:자원없음
   PRODUCT_NOT_FOUND(NOT_FOUND, "경매 상품 개체를 찾지 못했습니다."),

--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -3,10 +3,13 @@ package com.goodsending.order.controller;
 import com.goodsending.global.security.anotation.MemberId;
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.dto.response.UpdateShippingResponse;
 import com.goodsending.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,5 +40,20 @@ public class OrderController {
   public ResponseEntity<ReceiverInfoResponse> updateReceiverInfo(
       @MemberId Long memberId, @RequestBody ReceiverInfoRequest request){
     return ResponseEntity.ok(orderService.updateReceiverInfo(memberId, request));
+  }
+
+  /**
+   * 판매자가 주문을 배송 출발 처리 합니다.
+   * @param memberId 로그인 유저 아이디 => 판매자 id
+   * @param orderId 주문 id
+   * @return 업데이트된 order 정보를 반환합니다.
+   * @author : jieun(je-pa)
+   */
+  @Operation(summary = "주문 배송 출발 처리",
+      description =  "판매자가 주문을 배송 출발 처리 합니다.")
+  @PutMapping("/{orderId}/delivery")
+  public ResponseEntity<UpdateShippingResponse> updateShipping(@MemberId Long memberId,
+      @PathVariable Long orderId){
+    return ResponseEntity.ok(orderService.updateShipping(memberId, orderId, LocalDateTime.now()));
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
+++ b/goodsending/src/main/java/com/goodsending/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.goodsending.order.controller;
 
 import com.goodsending.global.security.anotation.MemberId;
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.OrderResponse;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
 import com.goodsending.order.dto.response.UpdateShippingResponse;
 import com.goodsending.order.service.OrderService;
@@ -58,4 +59,19 @@ public class OrderController {
       @PathVariable Long orderId){
     return ResponseEntity.ok(orderService.updateShipping(memberId, orderId, LocalDateTime.now()));
   }
+
+  /**
+   * 수신자가 배송을 받은 후 거래확정을 합니다.
+   * @param memberId 로그인 유저 아이디 => 수신자(=낙찰자)id
+   * @param orderId 주문 id
+   * @return 업데이트된 order 정보를 반환합니다.
+   * @author : jieun(je-pa)
+   */
+  @Operation(summary = "수신자가 거래를 확정합니다.",
+      description = "수신자가 배송을 받은 후 거래확정을 합니다.")
+  @PutMapping("/{orderId}/confirm")
+  public ResponseEntity<OrderResponse> confirmOrder(@MemberId Long memberId, @PathVariable Long orderId) {
+    return ResponseEntity.ok(orderService.confirmOrder(memberId, orderId, LocalDateTime.now()));
+  }
+
 }

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/OrderResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/OrderResponse.java
@@ -1,0 +1,45 @@
+package com.goodsending.order.dto.response;
+
+import com.goodsending.order.entity.Order;
+import com.goodsending.order.type.OrderStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 04.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Builder
+public record OrderResponse(
+    Long orderId,
+
+    Long sellerId,
+
+    String receiverName,
+
+    String receiverCellNumber,
+
+    String receiverAddress,
+
+    LocalDateTime deliveryDateTime,
+
+    LocalDateTime confirmedDateTime,
+
+    OrderStatus status
+
+) {
+    public static OrderResponse from(Order order) {
+        return OrderResponse.builder()
+            .orderId(order.getId())
+            .sellerId(order.getBid().getProduct().getMember().getMemberId())
+            .receiverName(order.getReceiverName())
+            .receiverCellNumber(order.getReceiverCellNumber())
+            .receiverAddress(order.getReceiverAddress())
+            .deliveryDateTime(order.getDeliveryDateTime())
+            .confirmedDateTime(order.getConfirmedDateTime())
+            .status(order.getStatus())
+            .build();
+    }
+}

--- a/goodsending/src/main/java/com/goodsending/order/dto/response/UpdateShippingResponse.java
+++ b/goodsending/src/main/java/com/goodsending/order/dto/response/UpdateShippingResponse.java
@@ -1,0 +1,42 @@
+package com.goodsending.order.dto.response;
+
+import com.goodsending.order.entity.Order;
+import com.goodsending.order.type.OrderStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+/**
+ * @author : jieun(je-pa)
+ * @Date : 2024. 08. 02.
+ * @Team : GoodsEnding
+ * @Project : goodsending-be :: goodsending
+ */
+@Builder
+public record UpdateShippingResponse(
+    Long orderId,
+
+    Long sellerId,
+
+    String receiverName,
+
+    String receiverCellNumber,
+
+    String receiverAddress,
+
+    LocalDateTime deliveryDateTime,
+
+    OrderStatus status
+
+) {
+    public static UpdateShippingResponse from(Order order) {
+        return UpdateShippingResponse.builder()
+            .orderId(order.getId())
+            .sellerId(order.getBid().getProduct().getMember().getMemberId())
+            .receiverName(order.getReceiverName())
+            .receiverCellNumber(order.getReceiverCellNumber())
+            .receiverAddress(order.getReceiverAddress())
+            .deliveryDateTime(order.getDeliveryDateTime())
+            .status(order.getStatus())
+            .build();
+    }
+}

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -88,10 +88,21 @@ public class Order extends BaseEntity {
     return this;
   }
 
+  public Order processConfirm(LocalDateTime confirmedDateTime){
+    this.confirmedDateTime = confirmedDateTime;
+    this.status = OrderStatus.COMPLETED;
+    return this;
+  }
+
   public boolean isPending(){
     return this.receiverCellNumber != null &&
         this.receiverAddress != null &&
         this.receiverName != null &&
         this.status == OrderStatus.PENDING;
+  }
+
+  public boolean isShipping(){
+    return this.deliveryDateTime != null
+        && this.status == OrderStatus.SHIPPING;
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/entity/Order.java
+++ b/goodsending/src/main/java/com/goodsending/order/entity/Order.java
@@ -70,11 +70,28 @@ public class Order extends BaseEntity {
     return this.bid.getMember().getMemberId().equals(memberId);
   }
 
+  public boolean isSellerId(Long memberId){
+    return this.bid.getProduct().getMember().getMemberId().equals(memberId);
+  }
+
   public Order updateReceiverInfo(ReceiverInfoRequest request){
     this.receiverAddress = request.receiverAddress();
     this.receiverName = request.receiverName();
     this.receiverCellNumber = request.receiverCellNumber();
     this.status = OrderStatus.PENDING;
     return this;
+  }
+
+  public Order updateShipping(LocalDateTime deliveryDateTime){
+    this.status = OrderStatus.SHIPPING;
+    this.deliveryDateTime = deliveryDateTime;
+    return this;
+  }
+
+  public boolean isPending(){
+    return this.receiverCellNumber != null &&
+        this.receiverAddress != null &&
+        this.receiverName != null &&
+        this.status == OrderStatus.PENDING;
   }
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
@@ -13,4 +13,6 @@ public interface OrderQueryDslRepository {
   Optional<Order> findOrderWithBidById(Long orderId);
 
   Optional<Order> findOrderWithBidAndProductById(Long orderId);
+
+  Optional<Order> findOrderWithBidAndProductAndSellerById(Long orderId);
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
  */
 public interface OrderQueryDslRepository {
   Optional<Order> findOrderWithBidById(Long orderId);
+
+  Optional<Order> findOrderWithBidAndProductById(Long orderId);
 }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.goodsending.order.repository;
 
 import static com.goodsending.bid.entity.QBid.bid;
 import static com.goodsending.order.entity.QOrder.order;
+import static com.goodsending.product.entity.QProduct.product;
 
 import com.goodsending.order.entity.Order;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,6 +27,16 @@ public class OrderQueryDslRepositoryImpl implements  OrderQueryDslRepository {
     return Optional.ofNullable(queryFactory
         .selectFrom(order)
         .leftJoin(order.bid, bid).fetchJoin()
+        .where(order.id.eq(orderId))
+        .fetchOne());
+  }
+
+  @Override
+  public Optional<Order> findOrderWithBidAndProductById(Long orderId) {
+    return Optional.ofNullable(queryFactory
+        .selectFrom(order)
+        .innerJoin(order.bid, bid).fetchJoin()
+        .innerJoin(order.bid.product, product).fetchJoin()
         .where(order.id.eq(orderId))
         .fetchOne());
   }

--- a/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/repository/OrderQueryDslRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.goodsending.order.repository;
 
 import static com.goodsending.bid.entity.QBid.bid;
+import static com.goodsending.member.entity.QMember.member;
 import static com.goodsending.order.entity.QOrder.order;
 import static com.goodsending.product.entity.QProduct.product;
 
@@ -37,6 +38,17 @@ public class OrderQueryDslRepositoryImpl implements  OrderQueryDslRepository {
         .selectFrom(order)
         .innerJoin(order.bid, bid).fetchJoin()
         .innerJoin(order.bid.product, product).fetchJoin()
+        .where(order.id.eq(orderId))
+        .fetchOne());
+  }
+
+  @Override
+  public Optional<Order> findOrderWithBidAndProductAndSellerById(Long orderId) {
+    return Optional.ofNullable(queryFactory
+        .selectFrom(order)
+        .innerJoin(order.bid, bid).fetchJoin()
+        .innerJoin(order.bid.product, product).fetchJoin()
+        .innerJoin(product.member, member).fetchJoin()
         .where(order.id.eq(orderId))
         .fetchOne());
   }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.goodsending.order.service;
 
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
+import com.goodsending.order.dto.response.UpdateShippingResponse;
+import java.time.LocalDateTime;
 
 /**
  * @author : jieun(je-pa)
@@ -19,4 +21,6 @@ public interface OrderService {
    * @author : jieun(je-pa)
    */
   ReceiverInfoResponse updateReceiverInfo(Long memberId, ReceiverInfoRequest request);
+
+  UpdateShippingResponse updateShipping(Long memberId, Long orderId, LocalDateTime now);
 }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.goodsending.order.service;
 
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.OrderResponse;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
 import com.goodsending.order.dto.response.UpdateShippingResponse;
 import java.time.LocalDateTime;
@@ -23,4 +24,6 @@ public interface OrderService {
   ReceiverInfoResponse updateReceiverInfo(Long memberId, Long orderId, ReceiverInfoRequest request);
 
   UpdateShippingResponse updateShipping(Long memberId, Long orderId, LocalDateTime now);
+
+  OrderResponse confirmOrder(Long memberId, Long orderId, LocalDateTime now);
 }

--- a/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/order/service/OrderServiceImpl.java
@@ -1,12 +1,18 @@
 package com.goodsending.order.service;
 
+import com.goodsending.charge.entity.ChargeHistory;
+import com.goodsending.charge.repository.ChargeHistoryRepository;
+import com.goodsending.deposit.entity.Deposit;
+import com.goodsending.deposit.repository.DepositRepository;
 import com.goodsending.global.exception.CustomException;
 import com.goodsending.global.exception.ExceptionCode;
 import com.goodsending.order.dto.request.ReceiverInfoRequest;
+import com.goodsending.order.dto.response.OrderResponse;
 import com.goodsending.order.dto.response.ReceiverInfoResponse;
 import com.goodsending.order.dto.response.UpdateShippingResponse;
 import com.goodsending.order.entity.Order;
 import com.goodsending.order.repository.OrderRepository;
+import com.goodsending.product.entity.Product;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderServiceImpl implements OrderService{
 
   private final OrderRepository orderRepository;
+  private final ChargeHistoryRepository chargeHistoryRepository;
+  private final DepositRepository depositRepository;
+  private static final double CHARGE_PERCENT = 0.05;
+  private static final double POINT_PERCENT = 0.025;
 
   /**
    * 낙찰자가 주문에 대한 배송 정보를 입력합니다.
@@ -65,6 +75,63 @@ public class OrderServiceImpl implements OrderService{
     }
 
     return UpdateShippingResponse.from(order.updateShipping(now));
+  }
+
+  /**
+   * 수신자가 배송을 받은 후 거래확정을 합니다.
+   * @param memberId 수신자(=낙찰자) id
+   * @param orderId 주문 id
+   * @param now 현재시간
+   * @return 업데이트된 order 정보를 반환합니다.
+   */
+  @Override
+  @Transactional
+  public OrderResponse confirmOrder(Long memberId, Long orderId, LocalDateTime now) {
+    Order order = findOrderWithBidAndProductAndSellerById(orderId);
+
+    if(!order.isReceiverId(memberId)) {
+      throw CustomException.from(ExceptionCode.RECEIVER_ID_MISMATCH);
+    }
+
+    if(!order.isShipping()){
+      throw CustomException.from(ExceptionCode.ORDER_IS_NOT_SHIPPING);
+    }
+
+    processSettlement(order);
+
+    return OrderResponse.from(order.processConfirm(now));
+  }
+
+  // TODO: 동시성 문제 처리 필요
+  // 수수료, 포인트, 판매자 수익, 보증금 정산
+  private void processSettlement(Order order) {
+    Integer price = order.getBid().getPrice();
+    int charge = (int)(price * CHARGE_PERCENT);
+    int point = (int)(price * POINT_PERCENT);
+    int sellerRevenue = price - charge;
+    Deposit deposit = findDepositByProduct(order.getBid().getProduct());
+    int depositPrice = deposit.getPrice();
+
+    // 판매자 수익 + 보증금 환불
+    order.getBid().getProduct().getMember().addCash(sellerRevenue + depositPrice);
+    deposit.processReturn();
+
+    // 수신자 포인트 적립
+    order.getBid().getMember().addPoint(point);
+
+    // TODO: 누적금액 보증금 수정되면 같이 맞춰서 수수료도 수정필요(ex 누적금액)
+    // 수수료 내역 추가
+    chargeHistoryRepository.save(ChargeHistory.of(order, charge, charge));
+  }
+
+  private Deposit findDepositByProduct(Product product) {
+    return depositRepository.findByProduct(product);
+  }
+
+  private Order findOrderWithBidAndProductAndSellerById(Long orderId) {
+    return orderRepository.findOrderWithBidAndProductAndSellerById(orderId).orElseThrow(
+        () -> CustomException.from(ExceptionCode.ORDER_NOT_FOUND)
+    );
   }
 
   private Order findOrderWithBidById(Long orderId) {


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #72 

## 작업 내용
-  거래를 확정합니다.
  - 낙찰자가 배송을 받은 후 거래확정을 합니다.
  - 거래확정일시가 업데이트 됩니다.
  - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
  - 판매자 수익 및 보증금 환불
    - 수익: 확정금액(=낙찰자의 입찰가)의 수수료를 제외한 금액이 판매자의 캐시에 적립됩니다.
    - 보증금: 상품을 생성할 때 제출했던 판매자의 보증금이 환불 됩니다.
  - 포인트: 확정금액(=낙찰자의 입찰가)의 2.5%의 포인트가 낙찰자 포인트에 적립됩니다.
  - 수수료: 확정금액(=낙찰자의 입찰가)의 5%의 수수료가 시스템에 적립됩니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석)를 업데이트했습니다.

## 기타
- 요청 예시
```http
### 수신자(=낙찰자)가 배송을 받고 거래 확정을 합니다.
PUT http://localhost:8080/api/orders/132/confirm
Content-Type: application/json
Authorization: Bearer {access token}
```

- 응답 body 예시 
```json
{
  "orderId": 132,
  "sellerId": 48,
  "receiverName": "박지은",
  "receiverCellNumber": "010-7777-7777",
  "receiverAddress": "ㅇㅇ시 ㅇㅇ동",
  "deliveryDateTime": "2024-08-05T17:07:31.668302",
  "confirmedDateTime": "2024-08-05T17:13:15.6975549",
  "status": "COMPLETED"
}
```

- 주문 조회 sql
```sql
    select
        o1_0.order_id,
        b1_0.(생략),
        p1_0.(생략),
        m1_0.(생략),
        p1_0.(생략),
        b1_0.(생략),
        o1_0.(생략)
    from
        orders o1_0 
    join
        bids b1_0 
            on b1_0.bid_id=o1_0.order_id 
    join
        products p1_0 
            on p1_0.product_id=b1_0.product_id 
    join
        members m1_0 
            on m1_0.member_id=p1_0.member_id 
    where
        o1_0.order_id=?
```