### PR TITLE
🐛 ️[#95] Refresh Token 인증 필터에서 제외

### DIFF
--- a/goodsending/src/main/java/com/goodsending/member/util/JwtUtil.java
+++ b/goodsending/src/main/java/com/goodsending/member/util/JwtUtil.java
@@ -67,6 +67,7 @@ public class JwtUtil {
 
     return Jwts.builder()
         .setSubject(email) // 사용자 식별자값(ID)
+        .claim("token_type", "refresh") // 토큰 종류 추가
         .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME)) // 만료 시간
         .setIssuedAt(date) // 발급일
         .signWith(key, signatureAlgorithm) // 암호화 알고리즘


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #95

## 작업 내용
- Refresh Token 생성 시 claim 필드 "token_type"의 값으로 refresh 추가
- JWT 검증 시 토큰에서 claim을 추출한다. 
- 추출한 claim에 필드 "token_type"의 값인 refresh이 있으면 true를 반환한다.
- 반환 값이 true이면 Refresh Token이므로 인증이 필요하다는 오류를 던진다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
