### PR TITLE
✨ [#100] 경매 상품 상세 조회 응답 Dto 변경

### DIFF
--- a/goodsending/src/main/java/com/goodsending/product/dto/response/ProductInfoDto.java
+++ b/goodsending/src/main/java/com/goodsending/product/dto/response/ProductInfoDto.java
@@ -2,13 +2,18 @@ package com.goodsending.product.dto.response;
 
 import com.goodsending.product.entity.Product;
 import com.goodsending.product.entity.ProductImage;
+import com.goodsending.product.type.ProductStatus;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class ProductInfoDto {
 
   private Long productId;
@@ -17,27 +22,17 @@ public class ProductInfoDto {
   private int price;
   private String introduction;
   private LocalDateTime startDateTime;
-  private LocalDateTime maxEndDate;
+  private LocalDateTime maxEndDateTime;
+  private LocalDateTime dynamicEndDateTime;
+  private Duration remainingExpiration;
   private int biddingCount;
+  private int bidderCount;
+  private Long likeCount;
+  private ProductStatus status;
   private List<ProductImageInfoDto> productImages;
-  // TODO : 입찰 여부 필드
 
-  @Builder
-  public ProductInfoDto(Long productId, Long memberId, String name, int price, String introduction,
-      LocalDateTime startDateTime, LocalDateTime maxEndDate, int biddingCount,
-      List<ProductImageInfoDto> productImages) {
-    this.productId = productId;
-    this.memberId = memberId;
-    this.name = name;
-    this.price = price;
-    this.introduction = introduction;
-    this.startDateTime = startDateTime;
-    this.maxEndDate = maxEndDate;
-    this.biddingCount = biddingCount;
-    this.productImages = productImages;
-  }
-
-  public static ProductInfoDto of(Product product, List<ProductImage> productImageList) {
+  public static ProductInfoDto of(Product product, List<ProductImage> productImageList,
+      Duration remainingExpiration) {
 
     List<ProductImageInfoDto> productImages = new ArrayList<>();
     for (ProductImage productImage : productImageList) {
@@ -52,8 +47,12 @@ public class ProductInfoDto {
         .price(product.getPrice())
         .introduction(product.getIntroduction())
         .startDateTime(product.getStartDateTime())
-        .maxEndDate(product.getMaxEndDateTime())
+        .maxEndDateTime(product.getMaxEndDateTime())
+        .dynamicEndDateTime(product.getDynamicEndDateTime())
+        .remainingExpiration(remainingExpiration)
         .biddingCount(product.getBiddingCount())
+        .bidderCount(product.getBidderCount())
+        .likeCount(product.getLikeCount())
         .productImages(productImages)
         .build();
   }

--- a/goodsending/src/main/java/com/goodsending/product/dto/response/ProductInfoDto.java
+++ b/goodsending/src/main/java/com/goodsending/product/dto/response/ProductInfoDto.java
@@ -53,6 +53,7 @@ public class ProductInfoDto {
         .biddingCount(product.getBiddingCount())
         .bidderCount(product.getBidderCount())
         .likeCount(product.getLikeCount())
+        .status(product.getStatus())
         .productImages(productImages)
         .build();
   }

--- a/goodsending/src/main/java/com/goodsending/product/entity/Product.java
+++ b/goodsending/src/main/java/com/goodsending/product/entity/Product.java
@@ -62,6 +62,9 @@ public class Product extends BaseEntity {
   @Column(name = "bidding_count", nullable = false)
   private int biddingCount;
 
+  @Column(name = "bidder_count", nullable = false)
+  private int bidderCount;
+
   @Column(name = "like_count", nullable = true)
   private Long likeCount;
 

--- a/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goodsending.product.service;
 
+import com.goodsending.bid.repository.ProductBidPriceMaxRepository;
 import com.goodsending.deposit.entity.Deposit;
 import com.goodsending.deposit.repository.DepositRepository;
 import com.goodsending.deposit.type.DepositStatus;
@@ -21,6 +22,7 @@ import com.goodsending.product.entity.ProductImage;
 import com.goodsending.product.repository.ProductImageRepository;
 import com.goodsending.product.repository.ProductRepository;
 import com.goodsending.product.type.ProductStatus;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +55,7 @@ public class ProductServiceImpl implements ProductService {
   private final S3Uploader s3Uploader;
   private final MemberRepository memberRepository;
   private final DepositRepository depositRepository;
+  private final ProductBidPriceMaxRepository productBidPriceMaxRepository;
 
   /**
    * 상품 등록
@@ -119,8 +122,9 @@ public class ProductServiceImpl implements ProductService {
 
     Product product = findProduct(productId);
     List<ProductImage> productImageList = findProductImageList(product);
+    Duration remainingExpiration = productBidPriceMaxRepository.getRemainingExpiration(productId);
 
-    return ProductInfoDto.of(product, productImageList);
+    return ProductInfoDto.of(product, productImageList, remainingExpiration);
   }
 
   /**


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #100 

## 작업 내용
- 경매 상품 상세 조회 정보 필드 추가
  - 입찰자 수 bidderCount 추가
  - 남은 유효 입찰 시간 remainingExpiration 추가
  - 상품 상태 status 추가
  - 찜 수 likeCount 추가
  - 변동 마감 시각 dynamicEndDateTime 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

### 기타
![스크린샷 2024-08-08 오후 4 47 21](https://github.com/user-attachments/assets/8cded1c5-a9da-4c55-951f-753e3636c099)

