### PR TITLE
✨ [#101] 입찰, 낙찰 시 상품 필드 변경

### DIFF
--- a/goodsending/src/main/java/com/goodsending/bid/dto/response/BidResponse.java
+++ b/goodsending/src/main/java/com/goodsending/bid/dto/response/BidResponse.java
@@ -22,7 +22,9 @@ public record BidResponse(
 
     Long productId,
 
-    Integer biddingCount
+    Integer biddingCount,
+
+    Integer bidderCount
 
 ) {
 
@@ -34,6 +36,7 @@ public record BidResponse(
         .memberId(bid.getMember().getMemberId())
         .productId(bid.getProduct().getId())
         .biddingCount(bid.getProduct().getBiddingCount())
+        .bidderCount(builder().bidderCount)
         .build();
   }
 }

--- a/goodsending/src/main/java/com/goodsending/bid/dto/response/BidWithDurationResponse.java
+++ b/goodsending/src/main/java/com/goodsending/bid/dto/response/BidWithDurationResponse.java
@@ -24,6 +24,8 @@ public record BidWithDurationResponse(
 
     Integer biddingCount,
 
+    Integer bidderCount,
+
     Duration remainDuration
 ) {
 
@@ -35,6 +37,7 @@ public record BidWithDurationResponse(
         .memberId(bid.memberId())
         .productId(bid.productId())
         .biddingCount(bid.biddingCount())
+        .bidderCount(bid.bidderCount())
         .remainDuration(remainDuration)
         .build();
   }

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepository.java
@@ -13,6 +13,11 @@ import org.springframework.data.domain.Slice;
  * @Project : goodsending-be :: goodsending
  */
 public interface BidQueryDslRepository {
+
+  Long countByProduct(Long productId);
+
+  Long countDistinctMembersByProduct(Long productId);
+
   List<Bid> findByProductId(Long productId);
 
   Slice<BidWithProductResponse> findBidWithProductResponseList(BidListByMemberRequest bidListRequest);

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidQueryDslRepositoryImpl.java
@@ -33,6 +33,24 @@ public class BidQueryDslRepositoryImpl implements BidQueryDslRepository {
   private final JPAQueryFactory queryFactory;
 
   @Override
+  public Long countByProduct(Long productId) {
+    return queryFactory
+        .select(bid.count())
+        .from(bid)
+        .where(bid.product.id.eq(productId))
+        .fetchOne();
+  }
+
+  @Override
+  public Long countDistinctMembersByProduct(Long productId) {
+    return queryFactory
+        .select(bid.member.countDistinct())
+        .from(bid)
+        .where(bid.product.id.eq(productId))
+        .fetchOne();
+  }
+
+  @Override
   public List<Bid> findByProductId(Long productId) {
     QBid bid = QBid.bid;
     return queryFactory

--- a/goodsending/src/main/java/com/goodsending/bid/repository/BidRepository.java
+++ b/goodsending/src/main/java/com/goodsending/bid/repository/BidRepository.java
@@ -1,10 +1,7 @@
 package com.goodsending.bid.repository;
 
 import com.goodsending.bid.entity.Bid;
-import com.goodsending.product.entity.Product;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 /**
  * @Date : 2024. 07. 25.
@@ -13,7 +10,5 @@ import org.springframework.data.jpa.repository.Query;
  * @Project : goodsending-be :: goodsending
  */
 public interface BidRepository extends JpaRepository<Bid, Long>, BidQueryDslRepository {
-  @Query("SELECT COUNT(b) FROM Bid b WHERE b.product = :product")
-  Long countByProduct(@Param("product") Product product);
 
 }

--- a/goodsending/src/main/java/com/goodsending/bid/service/BidServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/bid/service/BidServiceImpl.java
@@ -67,8 +67,10 @@ public class BidServiceImpl implements BidService {
     // 입찰 내역이 생성된다.
     Bid save = bidRepository.save(Bid.of(member, product, request));
 
+    // 입찰수 변경
+    product.setBiddingCount(bidRepository.countByProduct(product.getId()));
     // 입찰자 수 변경
-    product.setBiddingCount(bidRepository.countByProduct(product));
+    product.setBidderCount(bidRepository.countDistinctMembersByProduct(product.getId()));
 
     // 입찰 메시지 이벤트 발행
     eventPublisher.publishEvent(CreateProductMessageEvent.of(

--- a/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
@@ -2,6 +2,7 @@ package com.goodsending.global.redis.handler;
 
 import com.goodsending.bid.entity.Bid;
 import com.goodsending.bid.repository.BidRepository;
+import com.goodsending.bid.repository.ProductBidPriceMaxRepository;
 import com.goodsending.bid.type.BidStatus;
 import com.goodsending.global.exception.CustomException;
 import com.goodsending.global.exception.ExceptionCode;
@@ -9,6 +10,7 @@ import com.goodsending.member.entity.Member;
 import com.goodsending.order.entity.Order;
 import com.goodsending.order.repository.OrderRepository;
 import com.goodsending.product.entity.Product;
+import com.goodsending.product.type.ProductStatus;
 import com.goodsending.productmessage.event.CreateProductMessageEvent;
 import com.goodsending.productmessage.type.MessageType;
 import java.time.LocalDateTime;
@@ -47,7 +49,8 @@ public class BidPriceMaxKeyExpirationHandler implements RedisMessageHandler {
   @Override
   @Transactional
   public void handle(String message) {
-    long productId = Long.parseLong(message.split(":")[1]);
+    long productId = Long.parseLong(
+        message.substring(ProductBidPriceMaxRepository.KEY_PREFIX.length()));
     List<Bid> bids = bidRepository.findByProductId(productId);
     if (bids.isEmpty()) {
       throw CustomException.from(ExceptionCode.BID_NOT_FOUND);
@@ -59,8 +62,8 @@ public class BidPriceMaxKeyExpirationHandler implements RedisMessageHandler {
 
   private void setProduct(List<Bid> bids) {
     Product product = bids.get(0).getProduct();
-    product.setBiddingCount((long) bids.size());
     product.setDynamicEndDateTime(LocalDateTime.now());
+    product.setStatus(ProductStatus.ENDED);
   }
 
   private void handlerBids(List<Bid> bids) {

--- a/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
+++ b/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
@@ -17,6 +17,7 @@ public record ProductMessageDto(
     String message,
     int price,
     int biddingCount,
+    int bidderCount,
     MessageType type
 ) {
   public static ProductMessageDto of(ProductMessageHistory history, int price){
@@ -26,6 +27,7 @@ public record ProductMessageDto(
         .message(history.getMessage())
         .price(price)
         .biddingCount(history.getProduct().getBiddingCount())
+        .bidderCount(history.getProduct().getBidderCount())
         .type(history.getType())
         .build();
   }

--- a/goodsending/src/main/java/com/goodsending/product/entity/Product.java
+++ b/goodsending/src/main/java/com/goodsending/product/entity/Product.java
@@ -145,4 +145,12 @@ public class Product extends BaseEntity {
     }
     this.biddingCount = (int)biddingCount.longValue();
   }
+
+  public void setBidderCount(Long bidderCount) {
+    if(bidderCount == null) {
+      this.bidderCount = 0;
+      return;
+    }
+    this.bidderCount = (int)bidderCount.longValue();
+  }
 }


### PR DESCRIPTION
- 입찰자수, 입찰수, 종료

## #️⃣연관된 이슈
- 이슈 번호: #101 

## 작업 내용
-  입찰 시 입찰자수와 입찰수를 카운팅해서 업데이트 시켜줍니다.
- 낙찰 시 상품의 상태를 종료 시켜줍니다.
- 소켓 메시지도 bidderCount를 추가해줍니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석 등)를 업데이트했습니다.
