### PR TITLE
🐛 [#115] BidResponse 잘못된 세팅

### DIFF
--- a/goodsending/src/main/java/com/goodsending/bid/dto/response/BidResponse.java
+++ b/goodsending/src/main/java/com/goodsending/bid/dto/response/BidResponse.java
@@ -36,7 +36,7 @@ public record BidResponse(
         .memberId(bid.getMember().getMemberId())
         .productId(bid.getProduct().getId())
         .biddingCount(bid.getProduct().getBiddingCount())
-        .bidderCount(builder().bidderCount)
+        .bidderCount(bid.getProduct().getBidderCount())
         .build();
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #115 

## 작업 내용
- bidderCount(bid.getProduct().getBidderCount()) 로 세팅해주었습니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 문서(코드, 주석 등)를 업데이트했습니다.

### 기타 

```java
public static BidResponse from(Bid bid) {
    return BidResponse.builder()
        .bidId(bid.getId())
        .price(bid.getPrice())
        .usePoint(bid.getUsePoint())
        .memberId(bid.getMember().getMemberId())
        .productId(bid.getProduct().getId())
        .biddingCount(bid.getProduct().getBiddingCount())
        .bidderCount(bid.getProduct().getBidderCount())
        .build();
  }
```
