### PR TITLE
🐛 [#118] 경매 상품 목록 조회 조건 타입 변경

### DIFF
--- a/goodsending/src/main/java/com/goodsending/product/controller/ProductController.java
+++ b/goodsending/src/main/java/com/goodsending/product/controller/ProductController.java
@@ -2,13 +2,13 @@ package com.goodsending.product.controller;
 
 import com.goodsending.global.security.anotation.MemberId;
 import com.goodsending.product.dto.request.ProductCreateRequestDto;
-import com.goodsending.product.dto.request.ProductSearchCondition;
 import com.goodsending.product.dto.request.ProductUpdateRequestDto;
 import com.goodsending.product.dto.response.ProductCreateResponseDto;
 import com.goodsending.product.dto.response.ProductInfoDto;
 import com.goodsending.product.dto.response.ProductSummaryDto;
 import com.goodsending.product.dto.response.ProductUpdateResponseDto;
 import com.goodsending.product.service.ProductService;
+import com.goodsending.product.type.ProductStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -76,7 +76,14 @@ public class ProductController {
 
   /**
    * 경매 상품 목록 조회
-   * @param productSearchCondition 경매 상품 목록 조회 조건
+   * @param memberId 상품 등록 회원 아이디
+   * @param openProduct 구매 가능한 매물 선택 여부
+   * @param closedProduct 마감 된 매물 선택 여부
+   * @param keyword 검색어
+   * @param cursorStatus 사용자에게 응답해준 마지막 데이터의 상태
+   * @param cursorStartDateTime 사용자에게 응답해준 마지막 데이터의 경매 시작 시각
+   * @param cursorId 사용자에게 응답해준 마지막 데이터의 식별자값
+   * @param size 조회할 데이터 개수
    * @return 조회한 경매 상품 목록
    * @author : puclpu
    */
@@ -85,8 +92,18 @@ public class ProductController {
           + "내가 등록한 상품 목록 조회 시 memberId를, "
           + "필터링 검색의 경우 openProduct, closedProduct, keyword 를 조건으로 상품 목록을 조회한다.")
   @GetMapping
-  public ResponseEntity<Slice<ProductSummaryDto>> getProductSlice(@RequestBody ProductSearchCondition productSearchCondition) {
-    Slice<ProductSummaryDto> productSummaryDtoSlice = productService.getProductSlice(productSearchCondition);
+  public ResponseEntity<Slice<ProductSummaryDto>> getProductSlice(
+      @RequestParam(required = false) Long memberId,
+      @RequestParam(required = false) boolean openProduct,
+      @RequestParam(required = false) boolean closedProduct,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) ProductStatus cursorStatus,
+      @RequestParam(required = false) LocalDateTime cursorStartDateTime,
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(required = true, defaultValue = "15") int size) {
+    Slice<ProductSummaryDto> productSummaryDtoSlice = productService.getProductSlice(
+                                            memberId, openProduct, closedProduct, keyword,
+                                            cursorStatus, cursorStartDateTime, cursorId, size);
     return ResponseEntity.status(HttpStatus.OK).body(productSummaryDtoSlice);
   }
 

--- a/goodsending/src/main/java/com/goodsending/product/dto/request/ProductSearchCondition.java
+++ b/goodsending/src/main/java/com/goodsending/product/dto/request/ProductSearchCondition.java
@@ -2,9 +2,13 @@ package com.goodsending.product.dto.request;
 
 import com.goodsending.product.type.ProductStatus;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class ProductSearchCondition {
 
   // 상품 등록 회원 아이디
@@ -28,7 +32,18 @@ public class ProductSearchCondition {
   // 사용자에게 응답해준 마지막 데이터의 식별자값
   private Long cursorId;
 
-  // 조회할 데이터 개수
-  private int size;
+  public static ProductSearchCondition of(Long memberId, boolean openProduct, boolean closedProduct,
+      String keyword, ProductStatus cursorStatus, LocalDateTime cursorStartDateTime,
+      Long cursorId) {
+    return ProductSearchCondition.builder()
+        .memberId(memberId)
+        .openProduct(openProduct)
+        .closedProduct(closedProduct)
+        .keyword(keyword)
+        .cursorStatus(cursorStatus)
+        .cursorStartDateTime(cursorStartDateTime)
+        .cursorId(cursorId)
+        .build();
+  }
 
 }

--- a/goodsending/src/main/java/com/goodsending/product/service/ProductService.java
+++ b/goodsending/src/main/java/com/goodsending/product/service/ProductService.java
@@ -1,7 +1,6 @@
 package com.goodsending.product.service;
 
 import com.goodsending.product.dto.request.ProductCreateRequestDto;
-import com.goodsending.product.dto.request.ProductSearchCondition;
 import com.goodsending.product.dto.request.ProductUpdateRequestDto;
 import com.goodsending.product.dto.response.ProductCreateResponseDto;
 import com.goodsending.product.dto.response.ProductInfoDto;
@@ -21,7 +20,8 @@ public interface ProductService {
 
   ProductInfoDto getProduct(Long productId);
 
-  Slice<ProductSummaryDto> getProductSlice(ProductSearchCondition productSearchCondition);
+  Slice<ProductSummaryDto> getProductSlice(Long memberId, boolean openProduct, boolean closedProduct, String keyword, ProductStatus cursorStatus, LocalDateTime cursorStartDateTime,
+      Long cursorId, int size);
 
   ProductUpdateResponseDto updateProduct(Long productId, ProductUpdateRequestDto requestDto, List<MultipartFile> productImages, Long memberId,
       LocalDateTime now);

--- a/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
+++ b/goodsending/src/main/java/com/goodsending/product/service/ProductServiceImpl.java
@@ -129,14 +129,23 @@ public class ProductServiceImpl implements ProductService {
 
   /**
    * 경매 상품 목록 조회
-   * @param productSearchCondition 경매 상품 목록 조회 조건
+   * @param memberId 상품 등록 회원 아이디
+   * @param openProduct 구매 가능한 매물 선택 여부
+   * @param closedProduct 마감 된 매물 선택 여부
+   * @param keyword 검색어
+   * @param cursorStatus 사용자에게 응답해준 마지막 데이터의 상태
+   * @param cursorStartDateTime 사용자에게 응답해준 마지막 데이터의 경매 시작 시각
+   * @param cursorId 사용자에게 응답해준 마지막 데이터의 식별자값
+   * @param size 조회할 데이터 개수
    * @return 조회한 경매 상품 목록
    * @author : puclpu
    */
   @Override
   @Transactional(readOnly = true)
-  public Slice<ProductSummaryDto> getProductSlice(ProductSearchCondition productSearchCondition) {
-    int size = productSearchCondition.getSize();
+  public Slice<ProductSummaryDto> getProductSlice(
+          Long memberId, boolean openProduct, boolean closedProduct, String keyword,
+          ProductStatus cursorStatus, LocalDateTime cursorStartDateTime, Long cursorId, int size) {
+    ProductSearchCondition productSearchCondition = ProductSearchCondition.of(memberId, openProduct, closedProduct, keyword, cursorStatus, cursorStartDateTime, cursorId);
     Pageable pageable = PageRequest.of(0, size);
     Slice<ProductSummaryDto> productSummaryDtoSlice = productRepository.findByFiltersAndSort(productSearchCondition, pageable);
     return productSummaryDtoSlice;


### PR DESCRIPTION
- body 에서 parameter 로 변경

## #️⃣연관된 이슈
- 이슈 번호: #118

## 작업 내용
- 경매 상품 목록 조회 조건 타입 변경
  - body로 받는 방식에서 parameter로 받는 방식으로 변경
  - parameter로 받은 다음 ProductSearchCondtion Dto를 생성하여 전달

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
