### PR TITLE
✨ [#130] 채팅 메시지 응답 생성일시 필드 추가

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
+++ b/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
@@ -2,6 +2,7 @@ package com.goodsending.global.websocket.dto;
 
 import com.goodsending.productmessage.entity.ProductMessageHistory;
 import com.goodsending.productmessage.type.MessageType;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 /**
@@ -18,7 +19,8 @@ public record ProductMessageDto(
     int price,
     int biddingCount,
     int bidderCount,
-    MessageType type
+    MessageType type,
+    LocalDateTime createdDateTime
 ) {
   public static ProductMessageDto of(ProductMessageHistory history, int price){
     return ProductMessageDto.builder()
@@ -29,6 +31,7 @@ public record ProductMessageDto(
         .biddingCount(history.getProduct().getBiddingCount())
         .bidderCount(history.getProduct().getBidderCount())
         .type(history.getType())
+        .createdDateTime(history.getCreatedDateTime())
         .build();
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #130 

## 작업 내용
- 채팅 메시지 응답 DTO에 생성일시 필드를 추가합니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
