### PR TITLE
♻️ [#130] 채팅 메시지 응답 생성일시 필드 추가 빠진부분 추가

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
+++ b/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
@@ -36,13 +36,6 @@ public record ProductMessageDto(
   }
 
   public static ProductMessageDto of(ProductMessageHistory history){
-    return ProductMessageDto.builder()
-        .memberId(history.getMember().getMemberId())
-        .productId(history.getProduct().getId())
-        .message(history.getMessage())
-        .biddingCount(history.getProduct().getBiddingCount())
-        .bidderCount(history.getProduct().getBidderCount())
-        .type(history.getType())
-        .build();
+    return of(history, 0);
   }
 }

--- a/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
+++ b/goodsending/src/main/java/com/goodsending/global/websocket/dto/ProductMessageDto.java
@@ -2,6 +2,7 @@ package com.goodsending.global.websocket.dto;
 
 import com.goodsending.productmessage.entity.ProductMessageHistory;
 import com.goodsending.productmessage.type.MessageType;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 /**
@@ -18,7 +19,8 @@ public record ProductMessageDto(
     int price,
     int biddingCount,
     int bidderCount,
-    MessageType type
+    MessageType type,
+    LocalDateTime createdDateTime
 ) {
   public static ProductMessageDto of(ProductMessageHistory history, int price){
     return ProductMessageDto.builder()
@@ -29,6 +31,7 @@ public record ProductMessageDto(
         .biddingCount(history.getProduct().getBiddingCount())
         .bidderCount(history.getProduct().getBidderCount())
         .type(history.getType())
+        .createdDateTime(history.getCreatedDateTime())
         .build();
   }
 

--- a/goodsending/src/main/java/com/goodsending/productmessage/dto/response/ProductMessageResponse.java
+++ b/goodsending/src/main/java/com/goodsending/productmessage/dto/response/ProductMessageResponse.java
@@ -2,6 +2,7 @@ package com.goodsending.productmessage.dto.response;
 
 import com.goodsending.productmessage.type.MessageType;
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 
 /**
  * @Date : 2024. 08. 08.
@@ -14,7 +15,8 @@ public record ProductMessageResponse(
     Long memberId,
     Long productId,
     String message,
-    MessageType type
+    MessageType type,
+    LocalDateTime createdDateTime
 ) {
 
   @QueryProjection

--- a/goodsending/src/main/java/com/goodsending/productmessage/repository/ProductMessageHistoryQueryDslRepositoryImpl.java
+++ b/goodsending/src/main/java/com/goodsending/productmessage/repository/ProductMessageHistoryQueryDslRepositoryImpl.java
@@ -35,7 +35,8 @@ public class ProductMessageHistoryQueryDslRepositoryImpl implements ProductMessa
             productMessageHistory.member.memberId,
             productMessageHistory.product.id,
             productMessageHistory.message,
-            productMessageHistory.type
+            productMessageHistory.type,
+            productMessageHistory.createdDateTime
         ))
         .from(productMessageHistory)
         .innerJoin(productMessageHistory.product, product)


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #130 

## 작업 내용
- 채팅 메시지 응답 생성일시 필드 추가에 빠진부분이 있어 추가합니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

### 기타 

![image](https://github.com/user-attachments/assets/285356ef-350c-440a-9f83-449f01ba1cbb)

