### PR TITLE
♻️ [#137] 입찰 로직에서 member의 point가 null 이면 오류가 뜨는 로직 수정

### DIFF
--- a/goodsending/src/main/java/com/goodsending/member/entity/Member.java
+++ b/goodsending/src/main/java/com/goodsending/member/entity/Member.java
@@ -71,22 +71,18 @@ public class Member extends BaseEntity {
     this.password = encodedPassword;
   }
 
-  public void cashUpdate(Integer cash) {
+  public void cashUpdate(int cash) {
     this.cash = cash;
   }
 
-  public boolean isCashGreaterOrEqualsThan(Integer amount){
-    if (this.cash == null || amount == null) {
-      return false;
-    }
-    return this.cash >= amount;
+  public boolean isCashGreaterOrEqualsThan(int amount){
+    int effectiveCash = (this.cash != null) ? this.cash : 0;
+    return effectiveCash >= amount;
   }
 
-  public boolean isPointGreaterOrEqualsThan(Integer amount){
-    if(this.point == null || amount == null) {
-      return false;
-    }
-    return this.point >= amount;
+  public boolean isPointGreaterOrEqualsThan(int amount){
+    int effectivePoint = (this.point != null) ? this.point : 0;
+    return effectivePoint >= amount;
   }
 
   public void addCash(int cash) {
@@ -105,17 +101,23 @@ public class Member extends BaseEntity {
     this.point += point;
   }
 
-  public void deductCash(Integer amount) {
+  public void deductCash(int amount) {
     if(!this.isCashGreaterOrEqualsThan(amount)){
       throw CustomException.from(ExceptionCode.USER_CASH_MUST_BE_POSITIVE);
+    }
+    if(this.cash == null){
+      this.cash = 0;
     }
 
     this.cash -= amount;
   }
 
-  public void deductPoint(Integer amount) {
+  public void deductPoint(int amount) {
     if (!this.isPointGreaterOrEqualsThan(amount)) {
       throw CustomException.from(ExceptionCode.USER_POINT_MUST_BE_POSITIVE);
+    }
+    if(this.point == null){
+      this.point = 0;
     }
 
     this.point -= amount;


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #137 

## 작업 내용
- 입찰을 할 때 입찰하는 유저가 가진 포인트가 null이면 오류가 발생하여 null 처리를 다시 했습니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
