### PR TITLE
✨ [#146] 낙찰 시 상품 finalPrice 업데이트

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
+++ b/goodsending/src/main/java/com/goodsending/global/redis/handler/BidPriceMaxKeyExpirationHandler.java
@@ -10,7 +10,6 @@ import com.goodsending.member.entity.Member;
 import com.goodsending.order.entity.Order;
 import com.goodsending.order.repository.OrderRepository;
 import com.goodsending.product.entity.Product;
-import com.goodsending.product.type.ProductStatus;
 import com.goodsending.productmessage.event.CreateProductMessageEvent;
 import com.goodsending.productmessage.type.MessageType;
 import java.time.LocalDateTime;
@@ -56,14 +55,13 @@ public class BidPriceMaxKeyExpirationHandler implements RedisMessageHandler {
       throw CustomException.from(ExceptionCode.BID_NOT_FOUND);
     }
 
-    setProduct(bids);
+    processProductEnd(bids.get(0));
     handlerBids(bids);
   }
 
-  private void setProduct(List<Bid> bids) {
-    Product product = bids.get(0).getProduct();
-    product.setDynamicEndDateTime(LocalDateTime.now());
-    product.setStatus(ProductStatus.ENDED);
+  private void processProductEnd(Bid successBid) {
+    Product product = successBid.getProduct();
+    product.processEnd(LocalDateTime.now(), successBid.getPrice());
   }
 
   private void handlerBids(List<Bid> bids) {

--- a/goodsending/src/main/java/com/goodsending/product/entity/Product.java
+++ b/goodsending/src/main/java/com/goodsending/product/entity/Product.java
@@ -59,6 +59,7 @@ public class Product extends BaseEntity {
   @Column(name = "dynamic_end_date_time")
   private LocalDateTime dynamicEndDateTime;
 
+  @Setter
   @Column(name = "final_price", nullable = false)
   private int finalPrice;
 
@@ -155,5 +156,11 @@ public class Product extends BaseEntity {
       return;
     }
     this.bidderCount = (int)bidderCount.longValue();
+  }
+
+  public void processEnd(LocalDateTime dynamicEndDateTime, int finalPrice) {
+    this.dynamicEndDateTime = dynamicEndDateTime;
+    this.finalPrice = finalPrice;
+    this.status = ProductStatus.ENDED;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #146 

## 작업 내용
- 낙찰 시 상품 finalPrice를 낙찰가로 업데이트합니다.

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.