### PR TITLE
✨ [#193] redis 비밀번호 설정 추가

### DIFF
--- a/goodsending/src/main/java/com/goodsending/global/config/RedisConfig.java
+++ b/goodsending/src/main/java/com/goodsending/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -32,9 +33,17 @@ public class RedisConfig {
   @Value("${spring.data.redis.port}")
   private int port;
 
+  @Value("${spring.data.redis.password}")
+  private String password;
+
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(host, port);
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+    redisStandaloneConfiguration.setHostName(host);
+    redisStandaloneConfiguration.setPort(port);
+    redisStandaloneConfiguration.setPassword(password);
+    LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+    return lettuceConnectionFactory;
   }
 
 

--- a/goodsending/src/main/resources/application.yaml
+++ b/goodsending/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      password: ${REDIS_PASSWORD}
   servlet:
     multipart:
       max-file-size: 30MB


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #193

## 작업 내용
- redis 보안을 위한 비밀번호 설정
  - EC2 redis /etc/redis/redis.conf 파일 설정 수정
  - redis config 수정
  - yaml 파일 수정

## 체크리스트
- [X] 코드가 제대로 동작하는지 확인했습니다.
- [X] 문서를 업데이트했습니다.

## 참고한 자료

- [EC2 설정 참고 블로그](https://wookgu.tistory.com/26)
- [SpringBoot redisConfig 참고 블로그](https://velog.io/@chrkb1569/RedisCommandExecutionException-NOAUTH-Authentication-required)
- [EC2 start test 할 때 NOAUTH Authentication required 참고 블로그](https://minholee93.tistory.com/entry/ERROR-NOAUTH-Authentication-required)
